### PR TITLE
DELETEリクエスト対応、クエリ文字列(名前・生年月日)対応、名前のバリデーションを実装

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.0.3'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.0.3'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com.example'
@@ -9,14 +9,15 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -33,5 +33,11 @@ public class NameController {
     // 更新処理は省略
     return ResponseEntity.ok(Map.of("message", "name successfully updated"));
   }
-  
+
+  @DeleteMapping("/names/{id}")
+  public ResponseEntity<Map<String, String>> deleteName(@PathVariable("id") int id) {
+    // 削除処理は省略
+    return ResponseEntity.ok(Map.of("message", "name successfully deleted"));
+  }
+
 }

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class NameController {
 
   @GetMapping("/names")
-  public List<String> getNames(@Valid @NotBlank(message = "値はNullです。") @Size(max = 19) @RequestParam String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[uuuuMMdd][uuuu-MM-dd]") LocalDate birthday) {
+  public List<String> getNames(@Valid @NotBlank @Size(max = 19) @RequestParam String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[uuuuMMdd][uuuu-MM-dd]") LocalDate birthday) {
     String birthdayString;
     if (birthday != null) {
       birthdayString = birthday.format(DateTimeFormatter.ofPattern("uuuu/MM/dd"));

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -1,7 +1,11 @@
 package com.example.restapi;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -11,12 +15,20 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
+@Validated
 @RestController
 public class NameController {
 
   @GetMapping("/names")
-  public List<String> getNames(@RequestParam(required = false) String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[yyyy-MM-dd][yyyyMMdd]") LocalDate birthday) {
-    return List.of(name, birthday.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")));
+  public List<String> getNames(@Valid @NotBlank(message = "値はNullです。") @Size(max = 19) @RequestParam String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[uuuuMMdd][uuuu-MM-dd]") LocalDate birthday) {
+    String birthdayString;
+    if (birthday != null) {
+      birthdayString = birthday.format(DateTimeFormatter.ofPattern("uuuu/MM/dd"));
+    } else {
+      birthdayString = "";
+    }
+    return List.of(name, birthdayString);
+
   }
 
   @PostMapping("/names")
@@ -32,7 +44,8 @@ public class NameController {
   }
 
   @PatchMapping("/names/{id}")
-  public ResponseEntity<Map<String, String>> updateName(@PathVariable("id") int id, @RequestBody NameUpdateForm nameUpdateForm) {
+  public ResponseEntity<Map<String, String>> updateName(@PathVariable("id") int id,
+                                                        @RequestBody NameUpdateForm nameUpdateForm) {
     // 更新処理は省略
     return ResponseEntity.ok(Map.of("message", "name successfully updated"));
   }

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -1,10 +1,13 @@
 package com.example.restapi;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -12,8 +15,8 @@ import java.util.Map;
 public class NameController {
 
   @GetMapping("/names")
-  public List<String> getNames() {
-    return List.of("koyama", "tanaka");
+  public List<String> getNames(@RequestParam(required = false) String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[yyyy-MM-dd][yyyyMMdd]") LocalDate birthday) {
+    return List.of(name, birthday.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")));
   }
 
   @PostMapping("/names")

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -12,7 +12,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Map;
 
 @Validated
@@ -20,15 +19,14 @@ import java.util.Map;
 public class NameController {
 
   @GetMapping("/names")
-  public List<String> getNames(@Valid @NotBlank @Size(max = 19) @RequestParam String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[uuuuMMdd][uuuu-MM-dd]") LocalDate birthday) {
+  public UserResponse getNames(@Valid @NotBlank @Size(max = 19) @RequestParam String name, @RequestParam(required = false) @DateTimeFormat(pattern = "[uuuuMMdd][uuuu-MM-dd]") LocalDate birthday) {
     String birthdayString;
     if (birthday != null) {
       birthdayString = birthday.format(DateTimeFormatter.ofPattern("uuuu/MM/dd"));
     } else {
       birthdayString = "";
     }
-    return List.of(name, birthdayString);
-
+    return new UserResponse(name, birthdayString);
   }
 
   @PostMapping("/names")

--- a/src/main/java/com/example/restapi/UserResponse.java
+++ b/src/main/java/com/example/restapi/UserResponse.java
@@ -1,0 +1,19 @@
+package com.example.restapi;
+
+public class UserResponse {
+  private String name;
+  private String birthday;
+
+  public UserResponse(String name, String birthday) {
+    this.name = name;
+    this.birthday = birthday;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getBirthday() {
+    return birthday;
+  }
+}


### PR DESCRIPTION
# 概要

- 第7回講座の実装例にDELETEリクエストを扱えるよう実装しました。
- クエリ文字列として名前(name)と生年月日(birthday=uuuuMMddまたはuuuu-MM-dd)を受け取れるようにしました。
- 名前については空文字、null、20文字以上の場合エラーとなるようにしました。
- 生年月日は省略可能な仕様としました(一応オリジナルの仕様です)。

# 動作確認の結果
DELETEリクエストの実行結果のスクショ
<img width="989" alt="PostmanでDELETEをリクエストした際のスクショ。HTTPステータスコードは200、レスポンスボディに{message:name successfully deleted}とある。" src="https://user-images.githubusercontent.com/122768264/222014632-f91a84ed-53c7-4708-92e9-8724f16f23fa.png">

名前と生年月日を指定したときのスクショ
<img width="466" alt="クエリ文字列をname=Justin&birthday=1994-03-01とすると、Justin,1993/03/01のリストが返される" src="https://user-images.githubusercontent.com/122768264/222013469-c0f632c7-5f3e-4350-b16b-ef7b5faac1ad.png">

名前だけを指定したときのスクショ
<img width="395" alt="name=Justinとすると、生年月日がない状態のリストが返される" src="https://user-images.githubusercontent.com/122768264/222013544-bb4fa457-223f-4bc9-ae2f-dfadd353ffd2.png">

名前が20文字以上のときのスクショ
<img width="1030" alt="nameが長すぎると、500エラーとなる" src="https://user-images.githubusercontent.com/122768264/222013990-6d2ee479-c4a4-4c79-9c52-448b0d220347.png">
↑HTTPステータスコードが400ではなく500であることが確認できました。